### PR TITLE
Correct date in share_cpp post

### DIFF
--- a/posts/share-cpp/index.qmd
+++ b/posts/share-cpp/index.qmd
@@ -3,7 +3,7 @@ title: "Sharing the C++ Code of an Rcpp Package"
 author:
   - name: "Pratik Gupte"
     orcid: "0000-0001-5294-7819"
-date: "2023-04-24"
+date: "2023-06-05"
 categories: [code sharing, R, R package, Rcpp, interoperability]
 format:
   html:


### PR DESCRIPTION
This PR fixes the date in the post on sharing C++ code to the date of the post's release, June 5th 2023.