### PR TITLE
Removed setup {renv} in quarto publish workflow

### DIFF
--- a/.github/workflows/quarto-publish.yml
+++ b/.github/workflows/quarto-publish.yml
@@ -17,8 +17,6 @@ jobs:
 
       - uses: r-lib/actions/setup-r@v2
 
-      - uses: r-lib/actions/setup-renv@v2
-
       - name: Publish to GitHub Pages (and render)
         uses: quarto-dev/quarto-actions/publish@v2
         with:


### PR DESCRIPTION
Removing {renv} from quarto publishing workflow to try and resolve https://github.com/epiverse-trace/epiverse-trace.github.io/actions/runs/5586632146.