### PR TITLE
Fix release post workflow and manually upload linelist post

### DIFF
--- a/.github/workflows/automate-release-post.yaml
+++ b/.github/workflows/automate-release-post.yaml
@@ -49,7 +49,7 @@ jobs:
               ~ gh::gh("/repos/{full_name}/releases", full_name = .x, per_page = 1)
             ) |>
             purrr::map(unlist, recursive = FALSE) |>
-            purrr::keep(~ isTRUE(lubridate::ymd_hms(.x$published_at) - lubridate::now() > -1))
+            purrr::keep(~ isTRUE(difftime(lubridate::ymd_hms(.x$published_at), lubridate::now(), units = "days") > -1))
 
           if (!is.null(release_today)) {
 

--- a/posts/linelist_v1.0.0/index.qmd
+++ b/posts/linelist_v1.0.0/index.qmd
@@ -13,12 +13,12 @@ Here is a automatically generated summary of the changes in this version.
 
 * Increased compatibility with dplyr is now documented and ensured through
 tests of all dplyr verbs on linelist objects as part of our testing & continuous
-integration system, as well as a new vignette: 
-<https://epiverse-trace.github.io/linelist/articles/compat-dplyr.html> 
+integration system, as well as a new vignette:
+<https://epiverse-trace.github.io/linelist/articles/compat-dplyr.html>
 (@Bisaloo, #53)
 
 * A new selection helper is provided for tidyverse users, based on the existing
-selectors provided by the tidyselect package: `has_tag()` (@Bisaloo, #61). By 
+selectors provided by the tidyselect package: `has_tag()` (@Bisaloo, #61). By
 feeding it a character vector of tags to operate on, you can work with dplyr
 verbs on specific tagged columns without having to explicitly use the column
 names:
@@ -30,13 +30,13 @@ names:
 
 ## Breaking changes
 
-* It is no longer possible to use `lost_tags_action()` within a pipeline. It 
+* It is no longer possible to use `lost_tags_action()` within a pipeline. It
 must now be set as a separate step. This makes the internal code more robust and
 clarifies what is part of the pipeline versus a global option (@Bisaloo, #79).
 
 * The `select_tags()` function is now deprecated to ensure we provide just one
 clear way to address a given issue and that our "happy path" is clearly
-signposted (@Bisaloo, #61). If you were using this function, we now recommend 
+signposted (@Bisaloo, #61). If you were using this function, we now recommend
 using the more explicit two-steps process:
 
   ```r
@@ -55,13 +55,13 @@ using the more explicit two-steps process:
     tags_df()
   ```
 
-* The custom `select.linelist()` method has been deprecated as providing a 
+* The custom `select.linelist()` method has been deprecated as providing a
 custom `[.linelist()` is sufficient to ensure compatibility with
 `dplyr::select()` default methods, including triggering `lost_tags_action()`
 on tag removal (@Bisaloo, #61).
 A full deletion of this method is not possible at the moment because we want to
 provide a smooth transition for users that relied on the custom `tags` argument
-of the `select.linelist()` method. It is now recommend instead to use the new 
+of the `select.linelist()` method. It is now recommend instead to use the new
 `has_tag()` selection helper:
 
   ```r
@@ -74,9 +74,8 @@ of the `select.linelist()` method. It is now recommend instead to use the new
   ```
 
 * The custom `rename.linelist()` method has been removed as providing a custom
-`names<-().linelist` method is sufficient to ensure compatibility with 
-`dplyr::rename()`, including appropriate modification of the tags. (@Bisaloo, 
-#60)
+`names<-().linelist` method is sufficient to ensure compatibility with
+`dplyr::rename()`, including appropriate modification of the tags. (@Bisaloo, #60)
 
 ## Documentation
 
@@ -86,18 +85,17 @@ of the `select.linelist()` method. It is now recommend instead to use the new
 
 ## Bug fixes
 
-* linelist is now explicitly marked as incompatible with data.table. 
-In practice, `make_linelist(x)` now errors if `x` inherits from `data.table` 
+* linelist is now explicitly marked as incompatible with data.table.
+In practice, `make_linelist(x)` now errors if `x` inherits from `data.table`
 (#55, @Bisaloo, based on discussions with @TimTaylor).
-* `[.linelist()` now works to subset by column when including just one argument 
+* `[.linelist()` now works to subset by column when including just one argument
 (#54, @Bisaloo). E.g., `x[1]`. As an indirect effect, this also improves
 compatibility with dplyr verbs that rely on this method (#51).
-* subsetting a linelist with extra tags (e.g., created via 
-`make_linelist(allow_extra = TRUE)`) no longer causes an error (#65, @Bisaloo; 
+* subsetting a linelist with extra tags (e.g., created via
+`make_linelist(allow_extra = TRUE)`) no longer causes an error (#65, @Bisaloo;
 reported by @TimTaylor in #63)
 
 ## Internal changes
 
 * testthat tests now run in parallel (#76, @Bisaloo)
 * testthat tests now warn on partial matching (#76, @Bisaloo)
-

--- a/posts/linelist_v1.0.0/index.qmd
+++ b/posts/linelist_v1.0.0/index.qmd
@@ -1,0 +1,103 @@
+---
+title: "linelist v1.0.0"
+author:
+  - name: "The Epiverse-TRACE development team"
+date: "2023-10-19"
+categories: [new-release]
+---
+
+We are very excited to announced the release of a new linelist version v1.0.0.
+Here is a automatically generated summary of the changes in this version.
+
+## New features
+
+* Increased compatibility with dplyr is now documented and ensured through
+tests of all dplyr verbs on linelist objects as part of our testing & continuous
+integration system, as well as a new vignette: 
+<https://epiverse-trace.github.io/linelist/articles/compat-dplyr.html> 
+(@Bisaloo, #53)
+
+* A new selection helper is provided for tidyverse users, based on the existing
+selectors provided by the tidyselect package: `has_tag()` (@Bisaloo, #61). By 
+feeding it a character vector of tags to operate on, you can work with dplyr
+verbs on specific tagged columns without having to explicitly use the column
+names:
+
+  ```r
+  x %>%
+    dplyr::select(has_tag(c("id", "date_of_onset")))
+  ```
+
+## Breaking changes
+
+* It is no longer possible to use `lost_tags_action()` within a pipeline. It 
+must now be set as a separate step. This makes the internal code more robust and
+clarifies what is part of the pipeline versus a global option (@Bisaloo, #79).
+
+* The `select_tags()` function is now deprecated to ensure we provide just one
+clear way to address a given issue and that our "happy path" is clearly
+signposted (@Bisaloo, #61). If you were using this function, we now recommend 
+using the more explicit two-steps process:
+
+  ```r
+  # Deprecated
+  x %>%
+    select_tags("age")
+
+  # Instead use
+  x %>%
+    tags_df() %>%
+    select(age)
+  
+  # Or
+  x %>%
+    select(has_tag("age")) %>%
+    tags_df()
+  ```
+
+* The custom `select.linelist()` method has been deprecated as providing a 
+custom `[.linelist()` is sufficient to ensure compatibility with
+`dplyr::select()` default methods, including triggering `lost_tags_action()`
+on tag removal (@Bisaloo, #61).
+A full deletion of this method is not possible at the moment because we want to
+provide a smooth transition for users that relied on the custom `tags` argument
+of the `select.linelist()` method. It is now recommend instead to use the new 
+`has_tag()` selection helper:
+
+  ```r
+  x %>%
+    dplyr::select(has_tag(c("id", "date_of_onset")))
+    
+  # Instead of
+  x %>%
+    select(tags = c("id", "date_of_onset"))
+  ```
+
+* The custom `rename.linelist()` method has been removed as providing a custom
+`names<-().linelist` method is sufficient to ensure compatibility with 
+`dplyr::rename()`, including appropriate modification of the tags. (@Bisaloo, 
+#60)
+
+## Documentation
+
+* added a hex logo thanks to David Mascarina's contribution (@dgmascarina)
+
+* added short lay description to README thanks to Emma Marty's contribution
+
+## Bug fixes
+
+* linelist is now explicitly marked as incompatible with data.table. 
+In practice, `make_linelist(x)` now errors if `x` inherits from `data.table` 
+(#55, @Bisaloo, based on discussions with @TimTaylor).
+* `[.linelist()` now works to subset by column when including just one argument 
+(#54, @Bisaloo). E.g., `x[1]`. As an indirect effect, this also improves
+compatibility with dplyr verbs that rely on this method (#51).
+* subsetting a linelist with extra tags (e.g., created via 
+`make_linelist(allow_extra = TRUE)`) no longer causes an error (#65, @Bisaloo; 
+reported by @TimTaylor in #63)
+
+## Internal changes
+
+* testthat tests now run in parallel (#76, @Bisaloo)
+* testthat tests now warn on partial matching (#76, @Bisaloo)
+


### PR DESCRIPTION
- [ ] The post specifies a license if you don't want to use the default CC BY
- [ ] All authors have an ORCID iD
- [ ] Relevant keywords / tags has been added. In particular, if you want your post to be shared on R-bloggers, you must tag it with `R`
- [ ] Images or other external resources have been committed and pushed
- [ ] The post uses [pure quarto syntax, rather than HTML or R code, unless necessary](../CONTRIBUTING.md#pure-quarto-syntax)

Right before merging:

- [ ] The `date` field has been updated
- [ ] A PR has been opened in the [`blueprints`](https://github.com/epiverse-trace/blueprints) to link to this post
- [ ] The post has been re-rendered and content of the `_freeze/` folder is up-to-date
