### PR TITLE
Fix grammar in release posts

### DIFF
--- a/_templates/release.qmd
+++ b/_templates/release.qmd
@@ -6,7 +6,7 @@ date: "{{ date }}"
 categories: [new-release]
 ---
 
-We are very excited to announced the release of a new {{ pkgname }} version {{ v }}.
+We are very excited to announce the release of a new {{ pkgname }} version {{ v }}.
 Here is an automatically generated summary of the changes in this version.
 
 {{ notes }}

--- a/posts/bpmodels_v0.3.1/index.qmd
+++ b/posts/bpmodels_v0.3.1/index.qmd
@@ -6,7 +6,7 @@ date: "2023-11-06"
 categories: [new-release]
 ---
 
-We are very excited to announced the release of a new bpmodels version v0.3.1.
+We are very excited to announce the release of a new bpmodels version v0.3.1.
 Here is an automatically generated summary of the changes in this version.
 
 ## Input validation

--- a/posts/linelist_v1.0.0/index.qmd
+++ b/posts/linelist_v1.0.0/index.qmd
@@ -6,7 +6,7 @@ date: "2023-10-19"
 categories: [new-release]
 ---
 
-We are very excited to announced the release of a new linelist version v1.0.0.
+We are very excited to announce the release of a new linelist version v1.0.0.
 Here is a automatically generated summary of the changes in this version.
 
 ## New features


### PR DESCRIPTION
This is just to fix a minor issue with grammar in the release posts. In particular, I changed "announced" to "announce".
