### PR TITLE
add link to git-rstudio-basics tutorial

### DIFF
--- a/learn/git-training-01/index.qmd
+++ b/learn/git-training-01/index.qmd
@@ -87,6 +87,7 @@ We will use Git within the Rstudio graphical interface and GitHub. For this you 
 
 ## Materials we used
 
+- [Tutorial used as a reference for the training](https://epiverse-trace.github.io/git-rstudio-basics/)
 - [Slides that we used in the training](https://docs.google.com/presentation/d/1kE13oZCoSwlXJL_UhvhiX6W0hNaE1ZEkFsHAX-Pl5o0/edit?usp=sharing) with notes expanding the content for instructors
 - [Template for our document with shared notes](https://docs.google.com/document/d/1p7BWfqG0-advDHmhzYas1WyhHIZQvLs1HWR39_o7X7k/edit?usp=sharing)
 - [Template for our pre-training form](https://docs.google.com/forms/d/1LsSsMmwuLIr_GCsw1K5AUxfCMb5_XiAlpno7up6zc8Q/copy)


### PR DESCRIPTION
- [x] The post specifies a license if you don't want to use the default CC BY
- [x] All authors have an ORCID iD
- [x] Relevant keywords / tags has been added. In particular, if you want your post to be shared on R-bloggers, you must tag it with `R`
- [x] Images or other external resources have been committed and pushed
- [x] The post uses [pure quarto syntax, rather than HTML or R code, unless necessary](../CONTRIBUTING.md#pure-quarto-syntax)

Right before merging:

- [ ] The `date` field has been updated
- [ ] All reviewers have been acknowledged in a short paragraph
- [ ] A PR has been opened in the [`blueprints`](https://github.com/epiverse-trace/blueprints) to link to this post
- [ ] The post has been re-rendered and content of the `_freeze/` folder is up-to-date
