### PR TITLE
Add Blog submenu to navigation

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -12,7 +12,14 @@ website:
         href: https://epiverse-trace.r-universe.dev/ui#packages
       - text: Get involved
         href: get-involved.qmd
-      - blog.qmd
+      - text: Blog
+        menu:
+          - text: Articles
+            url: "https://epiverse-trace.github.io/blog.html#category=R"
+          - text: Release notes
+            url: "https://epiverse-trace.github.io/blog.html#category=new-releases"
+          - text: All
+            url: "https://epiverse-trace.github.io/blog.html#category="
       - presentations.qmd
       - learn.qmd
     tools:

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -17,7 +17,7 @@ website:
           - text: Articles
             url: "https://epiverse-trace.github.io/blog.html#category=R"
           - text: Release notes
-            url: "https://epiverse-trace.github.io/blog.html#category=new-releases"
+            url: "https://epiverse-trace.github.io/blog.html#category=new-release"
           - text: All
             url: "https://epiverse-trace.github.io/blog.html#category="
       - presentations.qmd


### PR DESCRIPTION
This PR adds a Blog submenu as mentioned in #135. Given that this is an easy addition that helps improve navigation, I went ahead and added this. 

I added the original three categories to keep it short and sweet. @joshwlambert does this achieve the purpose you originally imagined over in #135?