### PR TITLE
Add an RSS link

### DIFF
--- a/blog.qmd
+++ b/blog.qmd
@@ -13,4 +13,4 @@ page-layout: full
 title-block-banner: true
 ---
 
-This blog is also available on [R-bloggers](https://www.r-bloggers.com/).
+This blog is available via [RSS](./blog.xml) and on [R-bloggers](https://www.r-bloggers.com/).

--- a/presentations.qmd
+++ b/presentations.qmd
@@ -11,3 +11,5 @@ listing:
 page-layout: full
 title-block-banner: true
 ---
+
+A feed of the presentations is also available via [RSS](./presentations.xml).


### PR DESCRIPTION
This PR adds a link to the RSS feed for the blog, on the blog page. I used the relative path so the link doesn't rely on a hard-coded domain name and is a bit more resilient in the future.

Happy to take any suggestions if there's other places to add RSS feeds. Otherwise, fixes #97.