### PR TITLE
Fix "All" blog subsection

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -19,7 +19,7 @@ website:
           - text: Release notes
             url: "https://epiverse-trace.github.io/blog.html#category=new-release"
           - text: All
-            url: "https://epiverse-trace.github.io/blog.html#category="
+            url: "https://epiverse-trace.github.io/blog.html"
       - presentations.qmd
       - learn.qmd
     tools:


### PR DESCRIPTION
To reproduce the issue, click on "Blog > Articles" first and then "Blog > All", and note how only the articles are visible.