### PR TITLE
Add step by step guide for contributing blogs

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+posts/ @Bisaloo @chartgerink

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -102,7 +102,7 @@ The "alex" GitHub Actions workflow can help you detect and fix such occurrences 
 
 #### Step by step
 
-To make contributing a blog post accessible, we outline an exact step by step guide below. We assume you are starting from an up to date `main` branch.
+To make contributing a blog post accessible, we outline an exact step by step guide below. We assume you are starting from an up to date `main` branch - so do not forget to pull the latest changes before starting with the following steps (e.g., `git pull origin`).
 
 1. Create a branch for the blog post (e.g., `git checkout -b title-blog`).
 2. Create a folder for your blog post under `posts/` (e.g., `posts/title-blog`).

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -109,7 +109,7 @@ To make contributing a blog post accessible, we outline an exact step by step gu
 3. Add a `index.qmd` file in the folder from point 2 (e.g., `posts/title-blog/index.qmd`). You can create your blog post in this file. Optionally add an `index.bib` in that same folder.
 4. Commit and push changes to remote.
 5. Create [pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request) and [request reviews](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review).
-6. Request at least one review and work through discussion points, until the pull request gets approved.
+6. Request at least one review and [work through discussion points](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/reviewing-changes-in-pull-requests/about-pull-request-reviews), until the pull request gets approved.
 7. The post gets merged after final checks [by one of the code owners](./CODEOWNERS).
 
 ### After the post is published

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -110,7 +110,7 @@ To make contributing a blog post accessible, we outline an exact step by step gu
 4. Commit and push changes to remote.
 5. Create pull request and request reviews.
 6. Request at least one review and work through discussion points, until the pull request gets approved.
-7. The post gets merged after final checks by one of the code owners.
+7. The post gets merged after final checks [by one of the code owners](./CODEOWNERS).
 
 ### After the post is published
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -108,7 +108,7 @@ To make contributing a blog post accessible, we outline an exact step by step gu
 2. Create a folder for your blog post under `posts/` (e.g., `posts/title-blog`).
 3. Add a `index.qmd` file in the folder from point 2 (e.g., `posts/title-blog/index.qmd`). You can create your blog post in this file. Optionally add an `index.bib` in that same folder.
 4. Commit and push changes to remote.
-5. Create pull request and request reviews.
+5. Create [pull request](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/creating-a-pull-request) and [request reviews](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review).
 6. Request at least one review and work through discussion points, until the pull request gets approved.
 7. The post gets merged after final checks [by one of the code owners](./CODEOWNERS).
 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -100,6 +100,18 @@ and everybody's experience, as describe in our Code of Conduct.
 In particular, we are paying extra attention to avoid dismissive or demotivating language, such as "obvious", "just", "straightforward", etc. 
 The "alex" GitHub Actions workflow can help you detect and fix such occurrences of demotivating language.
 
+#### Step by step
+
+To make contributing a blog post accessible, we outline an exact step by step guide below. We assume you are starting from an up to date `main` branch.
+
+1. Create a branch for the blog post (e.g., `git checkout -b title-blog`).
+2. Create a folder for your blog post under `posts/` (e.g., `posts/title-blog`).
+3. Add a `index.qmd` file in the folder from point 2 (e.g., `posts/title-blog/index.qmd`). You can create your blog post in this file. Optionally add an `index.bib` in that same folder.
+4. Commit and push changes to remote.
+5. Create pull request and request reviews.
+6. Request at least one review and work through discussion points, until the pull request gets approved.
+7. The post gets merged after final checks by one of the code owners.
+
 ### After the post is published
 
 Once your post is published, we already have some systems in place to try and advertise it in the community:


### PR DESCRIPTION
This PR adds a step by step guide for contributing a blog post, based on the comments by @jamesmbaazam in #159.

I also added a `CODEOWNERS` file, to have auto invites for reviews as there are some checks that must happen before merging (e.g., post date etc). This also helps us unburden blog contributors.

Fixes #159.

