### PR TITLE
Fix `//` in blog links

### DIFF
--- a/_quarto.yml
+++ b/_quarto.yml
@@ -2,7 +2,7 @@ project:
   type: website
 
 website:
-  site-url: "https://epiverse-trace.github.io/"
+  site-url: "https://epiverse-trace.github.io"
   favicon: hexlogo.png
   title: "Epiverse-TRACE developer space"
   description: "A place for Epiverse-TRACE developers to share their reflections, learnings, and showcase their work."


### PR DESCRIPTION
This PR fixes the double slash that arises at the bottom of the blog posts at the moment 👇 

![Screenshot 2024-02-07 at 16 16 10](https://github.com/epiverse-trace/epiverse-trace.github.io/assets/2946344/8f7c7d93-f9d7-4c6e-a17d-d01a5dc2d114)
