### PR TITLE
Add a few more non-GitHub contributors

### DIFF
--- a/_scripts/collect_contributor_data.R
+++ b/_scripts/collect_contributor_data.R
@@ -28,8 +28,12 @@ excluded_handles <- c(
 )
 # A vector of handles of contributors who contributed outside of GitHub
 included_handles <- c(
-  "Na-Nino",
-  "dgmascarina" # linelist logo and graphical summary
+  "CatalinaGU",
+  "dgmascarina", # linelist logo and graphical summary
+  "hawyndiaz",
+  "mauricio110785",
+  "modiazv",
+  "Na-Nino"
 )
 
 repos <- lapply(repos, function(x) {
@@ -52,7 +56,7 @@ df_list <- lapply(included_handles, function(x) {
     logins = user$login,
     contributions = NA,
     avatar = user$avatar_url,
-    type = "analysis"
+    type = "research"
   )
 })
 


### PR DESCRIPTION
This PR adds a few more non-GitHub contributors that have been mentioned to me directly.

I tried already rerunning the data locally, but for some reason I am missing contributors that are already on the homepage (it seems like most of the ones I was missing in my run were coming from `epiCo`).

But it's late, so leaving the PR as a draft before I figure it out next week. 

![](https://media.giphy.com/media/cqJ36SyeyNMFwWWasY/giphy.gif?cid=790b7611gdpscq7852r3sypncz2j3s3whpswbpwddctajf9n&ep=v1_gifs_search&rid=giphy.gif&ct=g)