### PR TITLE
Add footnote on RSS

### DIFF
--- a/blog.qmd
+++ b/blog.qmd
@@ -13,4 +13,6 @@ page-layout: full
 title-block-banner: true
 ---
 
-This blog is available via [RSS](./blog.xml) and on [R-bloggers](https://www.r-bloggers.com/).
+This blog is available via [RSS](./blog.xml)[^1] and on [R-bloggers](https://www.r-bloggers.com/).
+
+[^1]: What is RSS? You can [learn more about it with this great introductory post](https://www.businessinsider.com/guides/tech/what-is-rss-feed).


### PR DESCRIPTION
This PR adds a footnote on RSS to help people get started using it. The footnote also doubles as a tooltip which is revealed when hovered over.

Fixes #202.
