### PR TITLE
Add branch protection override

### DIFF
--- a/.github/workflows/collect-contributors.yaml
+++ b/.github/workflows/collect-contributors.yaml
@@ -28,16 +28,11 @@ jobs:
 
             - name: Collect contributor data
               run: Rscript _scripts/collect_contributor_data.R
-
-            - uses: peter-evans/create-pull-request@10db75894f6d53fc01c3bb0995e95bd03e583a62
-              id: cpr
-              with:
-                token: ${{ secrets.GITHUB_TOKEN }}
-                commit-message: Update `_data/epiverse_contributors.csv`
-                committer: epiverse-trace-bot <epiverse-trace-bot@users.noreply.github.com>
-                author: epiverse-trace-bot <epiverse-trace-bot@users.noreply.github.com>
-                branch: update-contributors
-                add-paths: _data
-                title: Automated update of contributor  data
-                reviewers: chartgerink
-                delete-branch: true
+            - uses: EndBug/add-and-commit@v9
+                with:
+                  author_name: epiverse-trace-bot
+                  author_email: epiverse-trace-bot@users.noreply.github.com
+                  message: "Update `_data/epiverse_contributors.csv`"
+                  add: '_data/epiverse_contributors.csv'
+                  token: ${{ secrets.SUDO_GITHUB_TOKEN }}
+                  

--- a/.github/workflows/collect-contributors.yaml
+++ b/.github/workflows/collect-contributors.yaml
@@ -16,6 +16,8 @@ jobs:
         steps:
             - name: Checkout repository
               uses: actions/checkout@v3
+              with:
+                token: ${{ secrets.SUDO_GITHUB_TOKEN }}
 
             - name: Setup R
               uses: r-lib/actions/setup-r@v2
@@ -34,4 +36,3 @@ jobs:
                 author_email: epiverse-trace-bot@users.noreply.github.com
                 message: "Update `_data/epiverse_contributors.csv`"
                 add: '_data/epiverse_contributors.csv'
-                token: ${{ secrets.SUDO_GITHUB_TOKEN }}

--- a/.github/workflows/collect-contributors.yaml
+++ b/.github/workflows/collect-contributors.yaml
@@ -29,10 +29,9 @@ jobs:
             - name: Collect contributor data
               run: Rscript _scripts/collect_contributor_data.R
             - uses: EndBug/add-and-commit@v9
-                with:
-                  author_name: epiverse-trace-bot
-                  author_email: epiverse-trace-bot@users.noreply.github.com
-                  message: "Update `_data/epiverse_contributors.csv`"
-                  add: '_data/epiverse_contributors.csv'
-                  token: ${{ secrets.SUDO_GITHUB_TOKEN }}
-                  
+              with:
+                author_name: epiverse-trace-bot
+                author_email: epiverse-trace-bot@users.noreply.github.com
+                message: "Update `_data/epiverse_contributors.csv`"
+                add: '_data/epiverse_contributors.csv'
+                token: ${{ secrets.SUDO_GITHUB_TOKEN }}


### PR DESCRIPTION
This PR adds the same branch protection override as in https://github.com/epiverse-trace/.github/pull/34 for the weekly updates to the contributor data.

> This PR uses the newly created Personal Access Token (PAT) SUDO_GITHUB_TOKEN to override the branch protection when updating the herdstat contribution graph. We replace the pull request action with a direct commit action.

> This helps reduce the unnecessary pull request load. The PAT is accessible in the actions of .github and the website repository only.
