### PR TITLE
Update bug in R script

### DIFF
--- a/_scripts/collect_contributor_data.R
+++ b/_scripts/collect_contributor_data.R
@@ -48,8 +48,6 @@ repos <- lapply(repos, function(x) {
 })
 
 ctbs <- do.call(rbind, repos)
-# Sum all the repeat contributors across repos
-ctbs$contributions <- ave(ctbs$contributions, ctbs$login, FUN = sum)
 # Remove duplicates
 result <- ctbs[!duplicated(ctbs$logins), ]
 


### PR DESCRIPTION
This PR corrects a bug in the R script for collecting contributor data that broke the workflow. 

Specifically, after we removed the contribution counts, the script failed when it tried to access the non-existent object. This was an oversight on my end as we removed those.