### PR TITLE
Do not propose automated blog post for patch releases

### DIFF
--- a/.github/workflows/automate-release-post.yaml
+++ b/.github/workflows/automate-release-post.yaml
@@ -51,7 +51,10 @@ jobs:
               ~ gh::gh("/repos/{full_name}/releases", full_name = .x, per_page = 1)
             ) |>
             purrr::map(unlist, recursive = FALSE) |>
-            purrr::keep(~ isTRUE(difftime(lubridate::ymd_hms(.x$published_at), lubridate::now(), units = "days") > -1))
+            purrr::keep(~ isTRUE(difftime(lubridate::ymd_hms(.x$published_at), lubridate::now(), units = "days") > -1)) |>
+            # Drop release with patch number != 0.
+            # We use negation (discard not 0), rather than keeping 0, to address the case where patch number may be unspecified
+            purrr::discard(~ grepl("\\d+\\.\\d+\\.[1-9]\\d*$", .x$tag_name))
 
           if (!is.null(release_today)) {
 


### PR DESCRIPTION
This makes some assumptions on git tag formatting but it seems reasonable to me. In particular, usethis, our recommend tool to create GitHub release, will generate tags with the following format `v1.0.0`.

This clashes with https://github.com/epiverse-trace/blueprints/pull/70 but matches @joshwlambert's request in #135:

> However, I would appreciate if there was a general consensus that we do not publish posts for patch releases, and then major and minor can be handled on a case-by-case basis.

I believe critical fixes should not be released as patches and this will spare us some notification spam.

What do you think?