### PR TITLE
Add resource workflow + page

### DIFF
--- a/.github/workflows/update-resource-page.yaml
+++ b/.github/workflows/update-resource-page.yaml
@@ -1,0 +1,31 @@
+name: Update resource page
+
+on:
+    workflow_dispatch:
+    schedule:
+      - cron: '0 8 * * *'
+  
+jobs:
+    run-r-script:
+        runs-on: ubuntu-latest
+        env:
+            GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+        permissions:
+            contents: write
+            pull-requests: write
+        steps:
+            - name: Checkout repository
+              uses: actions/checkout@v3
+              with:
+                # This helps override the branch protection later
+                token: ${{ secrets.SUDO_GITHUB_TOKEN }}
+            - name: Collect resource data
+              run: node _scripts/resource-retrieval-graphql Resources
+            - name: Re-render resource page
+              run: quarto render resource.qmd
+            - uses: EndBug/add-and-commit@v9
+              with:
+                author_name: epiverse-trace-bot
+                author_email: epiverse-trace-bot@users.noreply.github.com
+                message: "Update `./resources/`"
+                add: './resources/'

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -14,13 +14,15 @@ website:
         href: get-involved.qmd
       - text: Blog
         menu:
+          - text: All
+            url: "/blog.html"
           - text: Articles
             url: "/blog.html#category=R"
           - text: Release notes
             url: "/blog.html#category=new-release"
-          - text: All
-            url: "/blog.html"
-      - presentations.qmd
+          - text: Presentations
+            href: presentations.qmd
+      - href: resources.qmd
       - text: Learn
         href: learn.qmd
       - text: About

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -20,8 +20,8 @@ website:
             url: "/blog.html#category=R"
           - text: Release notes
             url: "/blog.html#category=new-release"
-          - text: Presentations
-            href: presentations.qmd
+      - text: Presentations
+        href: presentations.qmd
       - href: resources.qmd
       - text: Learn
         href: learn.qmd

--- a/_scripts/resource-retrieval-graphql.js
+++ b/_scripts/resource-retrieval-graphql.js
@@ -84,8 +84,8 @@ fetchDiscussions(null).then((discussions) => {
     fs.writeFile(
       `resources/${discussion.id}.qmd`,
       `---
-title: "${discussion.title}"
-url: ${discussion.url}
+title: "${discussion.title.replace(/"/g, '')}"
+url: "${discussion.url}"
 date: "${discussion.createdAt.substr(0,10)}"
 author: ${discussion.author}
 categories: [${discussion.labels}]

--- a/_scripts/resource-retrieval-graphql.js
+++ b/_scripts/resource-retrieval-graphql.js
@@ -1,0 +1,100 @@
+const fs = require("fs");
+
+// PAT only needs access to read issues
+const pat = process.env.GITHUB_TOKEN;
+
+const arg = process.argv[2];
+// Default to the announcements category
+const category = arg ? arg : "Announcements";
+
+async function fetchDiscussions(afterCursor) {
+  const query = `
+  {
+    repository(owner: "epiverse-trace", name: "epiverse-trace.github.io") {
+      discussions(first: 100, after: ${afterCursor ? '"' + afterCursor + '"' : null}, orderBy: {field: CREATED_AT, direction: DESC}) {
+        nodes {
+          id
+          title
+          url
+          createdAt
+          labels(first: 10) {
+            nodes {
+              name
+            }
+          }
+          author {
+            login
+          }
+          category {
+            name
+          }
+          upvoteCount
+        }
+        pageInfo {
+          endCursor
+          hasNextPage
+        }
+      }
+    }
+  }
+  `;
+
+  const response = await fetch("https://api.github.com/graphql", {
+    method: "POST",
+    headers: {
+      Authorization: `bearer ${pat}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ query }),
+  });
+
+  const json = await response.json();
+  const discussions = json.data.repository.discussions.nodes;
+  const { endCursor, hasNextPage } = json.data.repository.discussions.pageInfo;
+
+  if (hasNextPage) {
+    return discussions.concat(await fetchDiscussions(endCursor));
+  } else {
+    return discussions;
+  }
+}
+
+// When there are no next pages, process the responses
+fetchDiscussions(null).then((discussions) => {
+  let filteredDiscussions = discussions.filter(
+    (discussion) => discussion.category.name === category,
+  );
+
+  // Prepare the array for processing
+  filteredDiscussions = filteredDiscussions.map((discussion) => ({
+    ...discussion,
+    author: discussion.author.login,
+    category: discussion.category.name,
+    labels: discussion.labels.nodes.map((label) => label.name).join(", "),
+  }));
+
+  // Ensure directory exists
+  try {
+  fs.mkdirSync('resources/');
+  } catch {
+    console.log('resources/ already exists')
+  }
+
+  filteredDiscussions.forEach((discussion) => {
+    fs.writeFile(
+      `resources/${discussion.id}.qmd`,
+      `---
+title: "${discussion.title}"
+url: ${discussion.url}
+date: "${discussion.createdAt.substr(0,10)}"
+author: ${discussion.author}
+categories: [${discussion.labels}]
+upvotes: ${discussion.upvoteCount}
+---`,
+      (err) => {
+        if (err) throw err;
+        console.log(`resources/${discussion.id}.qmd saved`);
+      },
+    );
+  });
+});

--- a/custom_listing_resources.ejs
+++ b/custom_listing_resources.ejs
@@ -1,24 +1,22 @@
 ```{=html}
 <div class="archive list">
     <% for (const item of items) { %>
-
     <div class="quarto-post image-right" <%= metadataAttrs(item) %>>
-       
         <div class="body">
             <h3 class="no-anchor listing-title"><a href="<%- item.path %>" class="no-external"><%= item.title %></a></h3>
             <div class="listing-subtitle"><a href="<%- item.path %>" class="no-external"><%= item.subtitle %></a></div>
-            <span class="ratings">
-                <span class="rating listing-upvotes rating-upvotes-<%= item.upvotes %> ">Upvotes: <%= item.upvotes %></span>
-            </span>
-            <% if (item.categories) { %>
-            <div class="listing-categories">
-                <% for (const category of item.categories) { %>
-            <div class="listing-category" onclick="window.quartoListingCategory('<%=category%>'); return false;"><%= category %></div>
-                <% } %>
-            </div>
-            <% } %>
         </div>
-        <div class="metadata"><a href="<%- item.path %>" class="no-external">
+        <div class="metadata">
+            <div class="ratings">
+                <span class="rating listing-upvotes rating-upvotes-<%= item.upvotes %> ">👍 <%= item.upvotes %></span>
+            </div>
+            <% if (item.categories) { %>
+            <span class="listing-categories">
+                <% for (const category of item.categories) { %>
+            <span class="listing-category" onclick="window.quartoListingCategory('<%=category%>'); return false;"><%= category %></span>
+                <% } %>
+            </span>
+            <% } %>
             <span class="archive-item-date">
                 <span class="listing-date">
                     <%= item.date %>

--- a/custom_listing_resources.ejs
+++ b/custom_listing_resources.ejs
@@ -1,0 +1,31 @@
+```{=html}
+<div class="archive list">
+    <% for (const item of items) { %>
+
+    <div class="quarto-post image-right" <%= metadataAttrs(item) %>>
+       
+        <div class="body">
+            <h3 class="no-anchor listing-title"><a href="<%- item.path %>" class="no-external"><%= item.title %></a></h3>
+            <div class="listing-subtitle"><a href="<%- item.path %>" class="no-external"><%= item.subtitle %></a></div>
+            <span class="ratings">
+                <span class="rating listing-upvotes rating-upvotes-<%= item.upvotes %> ">Upvotes: <%= item.upvotes %></span>
+            </span>
+            <% if (item.categories) { %>
+            <div class="listing-categories">
+                <% for (const category of item.categories) { %>
+            <div class="listing-category" onclick="window.quartoListingCategory('<%=category%>'); return false;"><%= category %></div>
+                <% } %>
+            </div>
+            <% } %>
+        </div>
+        <div class="metadata"><a href="<%- item.path %>" class="no-external">
+            <span class="archive-item-date">
+                <span class="listing-date">
+                    <%= item.date %>
+                </span>
+            </span>
+        </div>
+    </div>
+    <% } %>
+</div>
+```

--- a/custom_listing_resources.ejs
+++ b/custom_listing_resources.ejs
@@ -3,8 +3,8 @@
     <% for (const item of items) { %>
     <div class="quarto-post image-right" <%= metadataAttrs(item) %>>
         <div class="body">
-            <h3 class="no-anchor listing-title"><a href="<%- item.path %>" class="no-external"><%= item.title %></a></h3>
-            <div class="listing-subtitle"><a href="<%- item.path %>" class="no-external"><%= item.subtitle %></a></div>
+            <h3 class="no-anchor listing-title"><a href="<%- item.url %>" class="no-external"><%= item.title %></a></h3>
+            <div class="listing-subtitle"><a href="<%- item.url %>" class="no-external"><%= item.subtitle %></a></div>
         </div>
         <div class="metadata">
             <div class="ratings">

--- a/resources.qmd
+++ b/resources.qmd
@@ -1,0 +1,22 @@
+---
+title: "Resources"
+listing:
+  contents: resources
+  sort:
+    - "date desc"
+    - "upvotes asc"
+  type: default
+  categories: true
+  filter-ui: true
+  sort-ui:
+    - date
+    - upvotes
+  template: custom_listing_resources.ejs
+  field-types:
+    upvotes: number
+page-layout: full
+title-block-banner: true
+comments: false
+---
+
+On this page, you can find resources shared on our discussion forum. [You can submit your own](https://github.com/orgs/epiverse-trace/discussions/new?category=resources) too!

--- a/resources.qmd
+++ b/resources.qmd
@@ -3,8 +3,7 @@ title: "Resources"
 listing:
   contents: resources
   sort:
-    - "date desc"
-    - "upvotes asc"
+    - "upvotes desc"
   type: default
   categories: true
   filter-ui: true
@@ -19,4 +18,4 @@ title-block-banner: true
 comments: false
 ---
 
-On this page, you can find resources shared on our discussion forum. [You can submit your own](https://github.com/orgs/epiverse-trace/discussions/new?category=resources) too!
+On this page, you can find resources shared on our discussion forum. [Submit your own](https://github.com/orgs/epiverse-trace/discussions/new?category=resources) and upvote the ones you like on GtiHub!

--- a/resources/D_kwDOIcolP84AZPXq.qmd
+++ b/resources/D_kwDOIcolP84AZPXq.qmd
@@ -1,0 +1,8 @@
+---
+title: "How to Run GitHub Actions Locally Using the act CLI Tool"
+url: "https://github.com/orgs/epiverse-trace/discussions/245"
+date: "2024-05-06"
+author: chartgerink
+categories: []
+upvotes: 1
+---


### PR DESCRIPTION
This PR adds a resource page and workflow. This builds on the work from #234 and does the following:

1. Collects all the discussion forum posts under the resource category (each morning)
2. Writes out the discussions to a file each under the `./resources/<id>.qmd`, with a YAML header containing the relevant metadata. Included metadata at this time:
  * title
  * url
  * date
  * author
  * categories (i.e., labels in the forum)
  * upvotes
3. Renders the listings under `./resources/` on the `/resources` page, displaying the upvote count, date added, and all categories

Given that the resources section on the forum is still empty, it currently will look empty upon merge. I add a video for display purposes:

https://github.com/epiverse-trace/epiverse-trace.github.io/assets/2946344/9eb5bd1f-6959-4181-b931-5ee1f595a509

---

I am pretty pleased I was able to set all of this up - and excited to hear your thoughts! Of course there's plenty of room for improvement, so looking forward to the feedback 😊
