### PR TITLE
Add merge schedule action

### DIFF
--- a/.github/workflows/scheduler.yml
+++ b/.github/workflows/scheduler.yml
@@ -8,6 +8,8 @@ on:
       - synchronize
   schedule:
     - cron: '0 8 * * *'
+permissions:
+  pull-requests: write
 
 jobs:
   merge_schedule:

--- a/.github/workflows/scheduler.yml
+++ b/.github/workflows/scheduler.yml
@@ -8,7 +8,7 @@ on:
       - synchronize
   schedule:
     # https://crontab.guru/every-hour
-    - cron: '0 * * * *'
+    - cron: '0 8 * * *'
 
 jobs:
   merge_schedule:

--- a/.github/workflows/scheduler.yml
+++ b/.github/workflows/scheduler.yml
@@ -1,0 +1,29 @@
+name: Merge Schedule
+
+on:
+  pull_request:
+    types:
+      - opened
+      - edited
+      - synchronize
+  schedule:
+    # https://crontab.guru/every-hour
+    - cron: '0 * * * *'
+
+jobs:
+  merge_schedule:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: gr2m/merge-schedule-action@v2
+        with:
+          # Merge method to use. Possible values are merge, squash or
+          # rebase. Default is merge.
+          merge_method: rebase
+          # Require all pull request statuses to be successful before
+          # merging. Default is `false`.
+          require_statuses_success: 'true'
+          # Label to apply to the pull request if the merge fails. Default is
+          # `automerge-fail`.
+          automerge_fail_label: 'merge-schedule-failed'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/scheduler.yml
+++ b/.github/workflows/scheduler.yml
@@ -7,7 +7,6 @@ on:
       - edited
       - synchronize
   schedule:
-    # https://crontab.guru/every-hour
     - cron: '0 8 * * *'
 
 jobs:

--- a/.github/workflows/scheduler.yml
+++ b/.github/workflows/scheduler.yml
@@ -9,6 +9,7 @@ on:
   schedule:
     - cron: '0 8 * * *'
 permissions:
+  contents: write
   pull-requests: write
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -1,0 +1,17 @@
+# Epiverse developer website
+
+This repository contains all the code, markdown files, scripts, assets, and so on used to create [the Epiverse website](https://epiverse-trace.github.io).
+
+## Rendering the website
+
+Please ensure you have Quarto installed on your command line. You should be able to run the following and render the entire website:
+
+```
+quarto render
+# individual pages
+quarto render <file>
+```
+
+## Scheduling pull requests
+
+Given that we sometimes want to merge pull requests at specific times, especially for blog posts, there is the option to schedule a merge attempt. To do so, add an ISO8601 compliant datetime command as such to the first post in the PR: `/schedule <datetime>` (e.g., `/schedule 2026-01-01` for January 1st, 2026).

--- a/README.md
+++ b/README.md
@@ -14,4 +14,4 @@ quarto render <file>
 
 ## Scheduling pull requests
 
-Given that we sometimes want to merge pull requests at specific times, especially for blog posts, there is the option to schedule a merge attempt. To do so, add an ISO8601 compliant datetime command as such to the first post in the PR: `/schedule <datetime>` (e.g., `/schedule 2026-01-01` for January 1st, 2026).
+Given that we sometimes want to merge pull requests at specific times, especially for blog posts, there is the option to schedule a merge attempt. To do so, add an ISO8601 compliant datetime command as such at the end of the first post in the PR: `/schedule <datetime>` (e.g., `/schedule 2026-01-01` for January 1st, 2026).


### PR DESCRIPTION
This PR adds an action to help with scheduling pull requests. It is based on the [`merge-schedule`](https://github.com/marketplace/actions/merge-schedule) action. It only merges PRs at the scheduled time if all the conditions are fulfilled:

- Checks pass
- Rebase merge possible
- Original PR comment includes a `/schedule <datetime>` command

This will helps us schedule blog posts, and prevent flooding the blog with posts at one time. We do not yet have a schedule itself, so this will be something a future community manager can set up.

Fixes #200.