### PR TITLE
Write out environment variables, use in PR

### DIFF
--- a/.github/workflows/automate-release-post.yaml
+++ b/.github/workflows/automate-release-post.yaml
@@ -68,11 +68,11 @@ jobs:
         id: cpr
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: Automated release blog post
+          commit-message: Automated release blog post `${{env.PACKAGE}}` - `${{env.PACKAGE_VERSION}}`
           committer: epiverse-trace-bot <epiverse-trace-bot@users.noreply.github.com>
           author: epiverse-trace-bot <epiverse-trace-bot@users.noreply.github.com>
           branch: automated-release-post
           branch-suffix: timestamp
           add-paths: posts
-          title: Automated release blog post
+          title: Automated release blog post `${{env.PACKAGE}}` - `${{env.PACKAGE_VERSION}}`
           delete-branch: true

--- a/.github/workflows/automate-release-post.yaml
+++ b/.github/workflows/automate-release-post.yaml
@@ -68,11 +68,11 @@ jobs:
         id: cpr
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: Automated release blog post `${{env.PACKAGE}}` - `${{env.PACKAGE_VERSION}}`
+          commit-message: Automated release blog post `${{ env.PACKAGE }}` - `${{ env.PACKAGE_VERSION }}`
           committer: epiverse-trace-bot <epiverse-trace-bot@users.noreply.github.com>
           author: epiverse-trace-bot <epiverse-trace-bot@users.noreply.github.com>
           branch: automated-release-post
           branch-suffix: timestamp
           add-paths: posts
-          title: Automated release blog post `${{env.PACKAGE}}` - `${{env.PACKAGE_VERSION}}`
+          title: Automated release blog post `${{ env.PACKAGE }}` - `${{ env.PACKAGE_VERSION }}`
           delete-branch: true

--- a/_scripts/create_release_post.R
+++ b/_scripts/create_release_post.R
@@ -7,6 +7,13 @@ create_release_post <- function(release_endpoint_response, pkg) {
   version <- release_endpoint_response$tag_name
   notes <- release_endpoint_response$body
 
+  if (Sys.getenv("GITHUB_ENV") != "") {
+    write(c(
+            paste0("PACKAGE=", package),
+            paste0("PACKAGE_VERSION=", version)), 
+    file = Sys.getenv("GITHUB_ENV"), append = TRUE)
+  }
+
   post_folder <- file.path("posts", paste(package, version, sep = "_"))
   dir.create(post_folder)
 


### PR DESCRIPTION
This PR writes out package variables while generating the automated release blog post, to the `GITHUB_ENV`. This subsequently is used in naming the blog post PR and the commit message.

I successfully tested the writing out of environment variables this way in [my personal repo](https://github.com/chartgerink/chartgerink/actions/workflows/r-test.yml). I am fairly confident this will work as is, but have not been able to test it directly in this flow exactly. If merged, I'll keep an eye out for the next release in any case.

Fixes #239.