### PR TITLE
Add acknowledgements to release posts

### DIFF
--- a/.github/workflows/automate-release-post.yaml
+++ b/.github/workflows/automate-release-post.yaml
@@ -25,9 +25,11 @@ jobs:
         with:
           packages: |
             gh
+            glue
             purrr
             lubridate
             knitr
+            usethis
 
       - name: Check for new releases
         run: |

--- a/_templates/release.qmd
+++ b/_templates/release.qmd
@@ -20,8 +20,7 @@ releases <- gh::gh("GET /repos/{owner}/{repo}/releases",
   purrr::discard(~ grepl("\\d+\\.\\d+\\.[1-9]\\d*$", .x$tag_name))
 
 ctbs <- usethis::use_tidy_thanks(
-  paste0('epiverse-trace/', 
-    "{{ pkgname }}"), 
+  "epiverse-trace/{{ pkgname }}", 
   from = releases[[2]][["tag_name"]], 
   to = "{{ version }}")
 ctbs <- ctbs[grep("github-actions\\[bot\\]", ctbs, invert = TRUE)]

--- a/_templates/release.qmd
+++ b/_templates/release.qmd
@@ -16,7 +16,9 @@ Here is an automatically generated summary of the changes in this version.
 ```{r ctbs, results='asis', echo=FALSE, message = FALSE}
 releases <- gh::gh("GET /repos/{owner}/{repo}/releases", 
                owner = "epiverse-trace",
-               repo = "{{ pkgname }}")
+               repo = "{{ pkgname }}") |>
+  purrr::discard(~ grepl("\\d+\\.\\d+\\.[1-9]\\d*$", .x$tag_name))
+
 ctbs <- usethis::use_tidy_thanks(
   paste0('epiverse-trace/', 
     "{{ pkgname }}"), 

--- a/_templates/release.qmd
+++ b/_templates/release.qmd
@@ -10,3 +10,11 @@ We are very excited to announce the release of a new {{ pkgname }} version {{ v 
 Here is an automatically generated summary of the changes in this version.
 
 {{ notes }}
+
+## Acknowledgements
+
+```{r ctbs, results='asis', echo=FALSE}
+ctbs <- suppressMessages(usethis::use_tidy_thanks(paste0('epiverse-trace/', "{{ pkgname }}")))
+ctbs <- ctbs[grep("github-actions\\[bot\\]", ctbs, invert = TRUE)]
+cat(glue::glue("[&#x0040;{ctbs}](https://github.com/{ctbs})"))
+```

--- a/_templates/release.qmd
+++ b/_templates/release.qmd
@@ -13,15 +13,15 @@ Here is an automatically generated summary of the changes in this version.
 
 ## Acknowledgements
 
-```{r ctbs, results='asis', echo=FALSE}
-releases <- suppressMessages(gh::gh("GET /repos/{owner}/{repo}/releases", 
+```{r ctbs, results='asis', echo=FALSE, message = FALSE}
+releases <- gh::gh("GET /repos/{owner}/{repo}/releases", 
                owner = "epiverse-trace",
-               repo = "{{ pkgname }}"))
-ctbs <- suppressMessages(usethis::use_tidy_thanks(
+               repo = "{{ pkgname }}")
+ctbs <- usethis::use_tidy_thanks(
   paste0('epiverse-trace/', 
     "{{ pkgname }}"), 
   from = releases[[length(releases) - 1]][["tag_name"]], 
-  to = "{{ version }}"))
+  to = "{{ version }}")
 ctbs <- ctbs[grep("github-actions\\[bot\\]", ctbs, invert = TRUE)]
 cat(glue::glue("[&#x0040;{ctbs}](https://github.com/{ctbs})"))
 ```

--- a/_templates/release.qmd
+++ b/_templates/release.qmd
@@ -14,7 +14,14 @@ Here is an automatically generated summary of the changes in this version.
 ## Acknowledgements
 
 ```{r ctbs, results='asis', echo=FALSE}
-ctbs <- suppressMessages(usethis::use_tidy_thanks(paste0('epiverse-trace/', "{{ pkgname }}")))
+releases <- suppressMessages(gh::gh("GET /repos/{owner}/{repo}/releases", 
+               owner = "epiverse-trace",
+               repo = "{{ pkgname }}"))
+ctbs <- suppressMessages(usethis::use_tidy_thanks(
+  paste0('epiverse-trace/', 
+    "{{ pkgname }}"), 
+  from = releases[[length(releases) - 1]][["tag_name"]], 
+  to = "{{ version }}"))
 ctbs <- ctbs[grep("github-actions\\[bot\\]", ctbs, invert = TRUE)]
 cat(glue::glue("[&#x0040;{ctbs}](https://github.com/{ctbs})"))
 ```

--- a/_templates/release.qmd
+++ b/_templates/release.qmd
@@ -22,7 +22,7 @@ releases <- gh::gh("GET /repos/{owner}/{repo}/releases",
 ctbs <- usethis::use_tidy_thanks(
   paste0('epiverse-trace/', 
     "{{ pkgname }}"), 
-  from = releases[[length(releases) - 1]][["tag_name"]], 
+  from = releases[[2]][["tag_name"]], 
   to = "{{ version }}")
 ctbs <- ctbs[grep("github-actions\\[bot\\]", ctbs, invert = TRUE)]
 cat(glue::glue("[&#x0040;{ctbs}](https://github.com/{ctbs})"))


### PR DESCRIPTION
This PR adds an auto-generated acknowledgements section to the release posts. It also adds the relevant packages to the github action, in order to ensure it can be run (`usethis` and `glue`).

Fixes #197.