### PR TITLE
Add DOI category

### DIFF
--- a/blog.qmd
+++ b/blog.qmd
@@ -8,7 +8,7 @@ listing:
   sort-ui: false
   filter-ui: false
   feed:
-    categories: [R package, R, posts]
+    categories: [R package, R, posts, DOI]
 page-layout: full
 title-block-banner: true
 ---

--- a/posts/renv-complications/index.qmd
+++ b/posts/renv-complications/index.qmd
@@ -4,7 +4,7 @@ author:
   - name: "Hugo Gruson"
     orcid: "0000-0002-4094-1476"
 date: "2024-01-31"
-categories: [R, reproducibility, renv]
+categories: [R, reproducibility, renv, DOI]
 format:
   html: 
     toc: true

--- a/posts/renv-complications/index.qmd
+++ b/posts/renv-complications/index.qmd
@@ -56,6 +56,7 @@ For example, a recent project (from 2023) was trying to install the version 0.60
 
 > error: ‘DOUBLE_XMAX’ undeclared (first use in this function); did you mean ‘DBL_MAX’?
 
+<!-- markdownlint-disable MD033 -->
 <details><summary>Click to see the full error message</summary>
 
 ```txt


### PR DESCRIPTION
This PR adds the new `DOI` category and adds one post by @Bisaloo to it. 

After merging, I can go ahead and send the feed https://epiverse-trace.github.io/blog-doi.xml to Rogue Scholar for indexing 👍 

This is step 1 for closing #113 - automatically adding the DOIs to the posts will come in a future PR.