### PR TITLE
Fix mpox blogpost published date

### DIFF
--- a/posts/mpox-preparedness/index.qmd
+++ b/posts/mpox-preparedness/index.qmd
@@ -103,4 +103,4 @@ In this post, we have outlined common outbreak analytics tasks relevant to the m
 [^2]: [Modeling Household Transmission of Clade I Mpox in the United States](https://www.cdc.gov/forecast-outbreak-analytics/about/modeling-forecasting/mpox-transmission.html)
 [^3]: [Risk of Clade 1 Mpox Outbreaks Among Gay, Bisexual, and Other Men Who Have Sex With Men in the United States](https://www.cdc.gov/forecast-outbreak-analytics/about/modeling-forecasting/mpox-gbmsm-technical-brief.html)
 
-*Thanks to Karim Mane (@Karim-Mane) and Chris Hartgerink (@chartgerink) for their valuable comments on earlier drafts of this post.*
+*Thanks to [Karim Mane](https://github.com/Karim-Mane) and [Chris Hartgerink](https://github.com/chartgerink) for their valuable comments on earlier drafts of this post.*

--- a/posts/mpox-preparedness/index.qmd
+++ b/posts/mpox-preparedness/index.qmd
@@ -7,7 +7,7 @@ author:
     orcid: "0000-0002-4094-147"
   - name: "Adam Kucharski"
     orcid: "0000-0001-8814-9421"
-date: "2024-01-04"
+date: "2024-07-04"
 categories: [Epiverse-TRACE, mpox, outbreak, outbreak-analytics, DOI]
 bibliography: index.bib
 format:


### PR DESCRIPTION
This PR corrects the publication date of the [mpox analytics blogpost](https://epiverse-trace.github.io/posts/mpox-preparedness/), which currently says Jan 1, 2024 instead of July 4, 2024.

It also fixes the links to the Reviewers' GitHub accounts.
