### PR TITLE
Add saving of raw contributor data

### DIFF
--- a/.github/workflows/collect-contributors.yaml
+++ b/.github/workflows/collect-contributors.yaml
@@ -31,6 +31,7 @@ jobs:
                 packages: |
                     gh
                     allcontributors
+                    dplyr
 
             - name: Collect contributor data
               run: Rscript _scripts/collect_contributor_data.R

--- a/_scripts/collect_contributor_data.R
+++ b/_scripts/collect_contributor_data.R
@@ -53,20 +53,22 @@ repos <- lapply(repos, function(x) {
 })
 
 ctbs <- do.call(rbind, repos)
-# Write out raw contributor data
-write.csv(ctbs, file = "_data/raw_epiverse_contributors.csv",
-          row.names = FALSE)
 
-# Retain only relevant info for about page
-ctbs <- ctbs[, c("logins", "avatar")]
-# Remove duplicates
-result <- ctbs[!duplicated(ctbs$logins), ]
+ctbs <- ctbs |>
+  dplyr::summarise(
+    type = toString(type),
+    repo = toString(repo),
+    avatar = toString(avatar),
+    .by = logins
+  )
 
 # Use lapply to get user data and create dataframes
 df_list <- lapply(included_handles, function(x) {
   user <- gh("GET /users/:username", username = x)
   data.frame(
     logins = user$login,
+    type = NA,
+    repo = NA,
     avatar = user$avatar_url
   )
 })

--- a/_scripts/collect_contributor_data.R
+++ b/_scripts/collect_contributor_data.R
@@ -44,11 +44,21 @@ repos <- lapply(repos, function(x) {
     # but keep an eye on https://github.com/ropenscilabs/allcontributors/issues/36 for a potentially
     # better solution.
     Sys.sleep(5)
-    return(one_repo[, c("logins", "avatar")])
+
+    # Add the repo name
+    one_repo$repo <- sprintf('%s/%s', org_name, x$name)
+
+    return(one_repo)
   }
 })
 
 ctbs <- do.call(rbind, repos)
+# Write out raw contributor data
+write.csv(ctbs, file = "_data/raw_epiverse_contributors.csv",
+          row.names = FALSE)
+
+# Retain only relevant info for about page
+ctbs <- ctbs[, c("logins", "avatar")]
 # Remove duplicates
 result <- ctbs[!duplicated(ctbs$logins), ]
 


### PR DESCRIPTION
This PR adds the recording of the raw contributor data over time, so we can identify how many new contributors have entered Epiverse TRACE, and if wanted, identify which existing contributors started contributing to new repositories.

The changes over time can be seen from the diff of this file over time (is the idea).
