### PR TITLE
Add package link to release blog post

### DIFF
--- a/_templates/release.qmd
+++ b/_templates/release.qmd
@@ -6,7 +6,7 @@ date: "{{ date }}"
 categories: [new-release]
 ---
 
-We are very excited to announce the release of a new {{ pkgname }} version {{ v }}.
+We are very excited to announce the release of a new [https://epiverse-trace.github.io/{{ pkgname }}]({{ pkgname }}) version {{ v }}.
 Here is an automatically generated summary of the changes in this version.
 
 {{ notes }}


### PR DESCRIPTION
If readers find the package relevant to their interests, they currently have no easy way to find more info and learn how to start using it. This PR aims to resolve this.
