### PR TITLE
Fix ambiguity in opening graph

### DIFF
--- a/posts/covid-analysis/index.qmd
+++ b/posts/covid-analysis/index.qmd
@@ -10,7 +10,7 @@ format:
     toc: true
 ---
 
-With [multiple reports](https://www.youtube.com/watch?v=i4frpQJMfn8) of influenza H5N1 cases that have no clear animal exposure, it is useful to consider what kinds of analysis would be required, and how easily this could be performed. As a starting point, this post reflects on some of the real-time work my colleagues and I contributed to inform the UK response to COVID-19.
+With [multiple reports](https://www.youtube.com/watch?v=i4frpQJMfn8) of influenza H5N1 cases that have no clear animal exposure, it is useful to consider what kinds of analysis would be required in the event of a new influenza pandemic, and how easily this could be performed. As a starting point, this post reflects on some of the real-time work my colleagues and I contributed to inform the UK response to COVID-19.
 
 ## Reflections on COVID-19 Contributions
 


### PR DESCRIPTION
This is a small tweak to fix an ambiguity in the opening paragraph of `covid-analysis/index.qmd`.