### PR TITLE
Link package name in automated release post

### DIFF
--- a/_templates/release.qmd
+++ b/_templates/release.qmd
@@ -6,7 +6,7 @@ date: "{{ date }}"
 categories: [new-release]
 ---
 
-We are very excited to announce the release of a new [{{ pkgname }}](https://epiverse-trace.github.io/{{ pkgname }}) version {{ v }}.
+We are very excited to announce the release of a new [{{ pkgname }}](<https://epiverse-trace.github.io/{{ pkgname }}>) version {{ v }}.
 Here is an automatically generated summary of the changes in this version.
 
 {{ notes }}

--- a/_templates/release.qmd
+++ b/_templates/release.qmd
@@ -6,7 +6,7 @@ date: "{{ date }}"
 categories: [new-release]
 ---
 
-We are very excited to announce the release of a new [https://epiverse-trace.github.io/{{ pkgname }}]({{ pkgname }}) version {{ v }}.
+We are very excited to announce the release of a new [{{ pkgname }}](https://epiverse-trace.github.io/{{ pkgname }}) version {{ v }}.
 Here is an automatically generated summary of the changes in this version.
 
 {{ notes }}


### PR DESCRIPTION
The PR reverses the markdown linking in the automated release post template (`_templates/release.qmd`). 

The automated release post for {epiparameter} v0.4.0 (#356) rendered the full URL. I've opened this PR as I assumed this is a mistake, but if not feel free to close.