### PR TITLE
Edit main gif and description

### DIFF
--- a/_components/Hero.jsx
+++ b/_components/Hero.jsx
@@ -24,11 +24,11 @@ function Hero() {
               <a href="https://epiverse.org" className="tw-underline">
                 Epiverse
               </a>{" "}
-              project, and is a suite of innovative software and tools for
-              global infectious disease analysis and response. From reading and
-              cleaning your data to estimating vaccine efficacy and policy
-              impact, Epiverse-TRACE provides robust tools so you can focus on
-              the results.
+              project, and is helping to grow an ecosystem for global 
+			  infectious disease analysis and response. From reading and 
+			  cleaning your data to estimating vaccine efficacy and policy impact, 
+			  Epiverse-TRACE aims to make common tasks easier and faster so you 
+			  can focus on the results.
             </p>
             <div className="tw-mt-10 tw-flex tw-items-center tw-justify-center tw-gap-x-6">
               <a

--- a/_components/Usp.jsx
+++ b/_components/Usp.jsx
@@ -35,8 +35,9 @@ function Usp() {
                   Better prepared, together
                 </h2>
                 <p className="tw-mt-6 tw-text-lg tw-leading-8 ">
-                  We are building robust, validated, and reliable tools that we
-                  know we will need in an epidemic. This is a direct response to
+                  We are building robust, validated, and reliable tools that we know we will need in an epidemic - 
+	  			  and collaborating with other teams who are working on complementary software. 
+	  			  This is a direct response to
                   not having them during the COVID-19 pandemic. This way we can
                   address a next epidemic with a head start.
                 </p>

--- a/_quarto.yml
+++ b/_quarto.yml
@@ -4,8 +4,8 @@ project:
 website:
   site-url: "https://epiverse-trace.github.io"
   favicon: hexlogo.png
-  title: "Epiverse-TRACE developer space"
-  description: "A place for Epiverse-TRACE developers to share their reflections, learnings, and showcase their work."
+  title: "Epiverse-TRACE: tools for outbreak analytics"
+  description: "A place for Epiverse-TRACE to share their reflections, learnings, and showcase available tools."
   navbar:
     left:
       - text: News


### PR DESCRIPTION
This is a PR to update the following elements of the `epiverse-trace.github.io` landing page to focus more on links with wider community, as discussed at Gambia summit and in recent meetings:
1. Main gif now showcases interoperability and documentation
2. Main copy focuses on community ecosystem, rather than just new Epiverse-TRACE tools
3. Page meta data (title etc) less developer focused