### PR TITLE
Add code auto-linking with `downlit`

### DIFF
--- a/.github/workflows/automate-release-post.yaml
+++ b/.github/workflows/automate-release-post.yaml
@@ -68,6 +68,11 @@ jobs:
           }
         shell: Rscript {0}
 
+      - name: Render Quarto Project
+        uses: quarto-dev/quarto-actions/render@v2
+        with:
+          path: posts/
+
       - uses: peter-evans/create-pull-request@10db75894f6d53fc01c3bb0995e95bd03e583a62
         id: cpr
         with:
@@ -77,6 +82,8 @@ jobs:
           author: epiverse-trace-bot <epiverse-trace-bot@users.noreply.github.com>
           branch: automated-release-post
           branch-suffix: timestamp
-          add-paths: posts
+          add-paths: |
+            posts
+            _freeze
           title: Automated release blog post `${{ env.PACKAGE }}` - `${{ env.PACKAGE_VERSION }}`
           delete-branch: true

--- a/.github/workflows/automate-release-post.yaml
+++ b/.github/workflows/automate-release-post.yaml
@@ -29,6 +29,8 @@ jobs:
             purrr
             lubridate
             knitr
+            pak
+            renv
             usethis
 
       - name: Check for new releases

--- a/_scripts/create_release_post.R
+++ b/_scripts/create_release_post.R
@@ -17,6 +17,10 @@ create_release_post <- function(release_endpoint_response, pkg) {
   post_folder <- file.path("posts", paste(package, version, sep = "_"))
   dir.create(post_folder)
 
+  pak::pak(sprintf('epiverse-trace/%s@%s', package, version))
+  options(renv.lockfile.version = 1)
+  renv::snapshot(prompt = FALSE, type = 'all')
+
   knitr::knit_expand(
     file.path("_templates", "release.qmd"),
     date = release_date,

--- a/_templates/release.qmd
+++ b/_templates/release.qmd
@@ -7,6 +7,10 @@ categories: [new-release]
 code-link: true
 ---
 
+```{r ctbs, results='asis', echo=FALSE, message = FALSE}
+library("{{ pkgname }}")
+```
+
 We are very excited to announce the release of a new [{{ pkgname }}](<https://epiverse-trace.github.io/{{ pkgname }}>) version {{ v }}.
 Here is an automatically generated summary of the changes in this version.
 

--- a/_templates/release.qmd
+++ b/_templates/release.qmd
@@ -4,6 +4,7 @@ author:
   - name: "The Epiverse-TRACE development team"
 date: "{{ date }}"
 categories: [new-release]
+code-link: true
 ---
 
 We are very excited to announce the release of a new [{{ pkgname }}](<https://epiverse-trace.github.io/{{ pkgname }}>) version {{ v }}.

--- a/renv.lock
+++ b/renv.lock
@@ -195,6 +195,26 @@
       ],
       "Hash": "33698c4b3127fc9f506654607fb73676"
     },
+"downlit": {
+      "Package": "downlit",
+      "Version": "0.4.4",
+      "Source": "Repository",
+      "Repository": "P3M",
+      "Requirements": [
+        "R",
+        "brio",
+        "desc",
+        "digest",
+        "evaluate",
+        "fansi",
+        "memoise",
+        "rlang",
+        "vctrs",
+        "withr",
+        "yaml"
+      ],
+      "Hash": "45a6a596bf0108ee1ff16a040a2df897"
+    },
     "dplyr": {
       "Package": "dplyr",
       "Version": "1.1.4",


### PR DESCRIPTION
This PR initiates the request to code link in the automated releases. I did my best to test the various steps in the automation process, but with GitHub actions the true test is when it runs.

I am opening the PR for review and feedback, and am happy to make further changes. I would consider this a first attempt, and I may be missing some bits.  

For renv, I [maintained an older version of the lockfile](https://rstudio.github.io/renv/news/index.html) to prevent excessive changes in this PR. I am not too confident with using renv, so a check on whether I did this correctly is much appreciated 😊
