### PR TITLE
Update `scheduler.yml` to use `SUDO_GITHUB_TOKEN`

### DIFF
--- a/.github/workflows/scheduler.yml
+++ b/.github/workflows/scheduler.yml
@@ -28,4 +28,4 @@ jobs:
           # `automerge-fail`.
           automerge_fail_label: 'merge-schedule-failed'
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.SUDO_GITHUB_TOKEN }}


### PR DESCRIPTION
This PR updates the secret used in the workflow that merges pull requests on a schedule. If I read the docs correctly, this enables the triggering of the `quarto-publish.yml` workflow downstream.

> If you do want to trigger a workflow from within a workflow run, you can use a GitHub App installation access token or a personal access token instead of GITHUB_TOKEN to trigger events that require a token.

I opted to use the sudo token, given that managing additional tokens for the actions may prove problematic down the line. If that is not preferred, I am happy to consider a sustainable alternative. My main consideration here is that it remains clear who authorized the token and can renew it if it expires.

