### PR TITLE
Use checkout@v4 in all workflows & remove PAT from scheduler workflow

### DIFF
--- a/.github/workflows/alex.yaml
+++ b/.github/workflows/alex.yaml
@@ -9,7 +9,7 @@ jobs:
     permissions:
       pull-requests: write
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: reviewdog/action-alex@8ffbae4a38ecf138503f7b9ea5cd2765ddde022f
         with:
           # Change reviewdog reporter if you need [github-pr-check,github-check,github-pr-review].

--- a/.github/workflows/automate-release-post.yaml
+++ b/.github/workflows/automate-release-post.yaml
@@ -15,7 +15,7 @@ jobs:
       pull-requests: write
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - uses: r-lib/actions/setup-r@v2
         with:

--- a/.github/workflows/collect-contributors.yaml
+++ b/.github/workflows/collect-contributors.yaml
@@ -15,7 +15,7 @@ jobs:
             pull-requests: write
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
               with:
                 token: ${{ secrets.SUDO_GITHUB_TOKEN }}
 

--- a/.github/workflows/lint-changed-quarto.yaml
+++ b/.github/workflows/lint-changed-quarto.yaml
@@ -12,7 +12,7 @@ jobs:
   lint-changed-quarto:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
 
       - run: npm install markdownlint-cli
 

--- a/.github/workflows/quarto-publish.yml
+++ b/.github/workflows/quarto-publish.yml
@@ -13,7 +13,7 @@ jobs:
       pages: write
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - uses: quarto-dev/quarto-actions/setup@v2
         with:

--- a/.github/workflows/scheduler.yml
+++ b/.github/workflows/scheduler.yml
@@ -27,5 +27,7 @@ jobs:
           # Label to apply to the pull request if the merge fails. Default is
           # `automerge-fail`.
           automerge_fail_label: 'merge-schedule-failed'
+      - name: Trigger re-render
         env:
-          GITHUB_TOKEN: ${{ secrets.SUDO_GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: gh workflow run quarto-publish.yaml

--- a/.github/workflows/scheduler.yml
+++ b/.github/workflows/scheduler.yml
@@ -15,6 +15,8 @@ permissions:
 jobs:
   merge_schedule:
     runs-on: ubuntu-latest
+    env:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - uses: gr2m/merge-schedule-action@v2
         with:
@@ -28,6 +30,4 @@ jobs:
           # `automerge-fail`.
           automerge_fail_label: 'merge-schedule-failed'
       - name: Trigger re-render
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: gh workflow run quarto-publish.yaml

--- a/.github/workflows/scheduler.yml
+++ b/.github/workflows/scheduler.yml
@@ -29,5 +29,8 @@ jobs:
           # Label to apply to the pull request if the merge fails. Default is
           # `automerge-fail`.
           automerge_fail_label: 'merge-schedule-failed'
+
+      - uses: actions/checkout@v4
+
       - name: Trigger re-render
         run: gh workflow run quarto-publish.yaml

--- a/.github/workflows/scheduler.yml
+++ b/.github/workflows/scheduler.yml
@@ -30,7 +30,5 @@ jobs:
           # `automerge-fail`.
           automerge_fail_label: 'merge-schedule-failed'
 
-      - uses: actions/checkout@v4
-
       - name: Trigger re-render
-        run: gh workflow run quarto-publish.yaml
+        run: gh workflow run quarto-publish.yml --repo epiverse-trace/epiverse-trace.github.io

--- a/.github/workflows/update-resource-page.yaml
+++ b/.github/workflows/update-resource-page.yaml
@@ -4,7 +4,7 @@ on:
     workflow_dispatch:
     schedule:
       - cron: '0 8 * * *'
-  
+
 jobs:
     run-r-script:
         runs-on: ubuntu-latest
@@ -15,7 +15,7 @@ jobs:
             pull-requests: write
         steps:
             - name: Checkout repository
-              uses: actions/checkout@v3
+              uses: actions/checkout@v4
               with:
                 # This helps override the branch protection later
                 token: ${{ secrets.SUDO_GITHUB_TOKEN }}


### PR DESCRIPTION
We still use a custom PAT in two workflows to bypass branch protection rule.

However, we don't seem to have an active branch protection rule at the moment so:

- do we want to keep not having a branch protection rule? We can then remove the custom PAT
- do we want a branch protection rule. If then, the likely recommended workflow would be something like https://github.com/krlmlr/pr-bots/blob/main/.github/workflows/write-file-branch-merge.yaml