### PR TITLE
Release blog post `simulist` - `v0.7.0`, `v0.7.1` & JOSS

### DIFF
--- a/_freeze/posts/simulist_joss/index/execute-results/html.json
+++ b/_freeze/posts/simulist_joss/index/execute-results/html.json
@@ -1,0 +1,15 @@
+{
+  "hash": "f3b7c0417d1afab251bef44bbbc9bfae",
+  "result": {
+    "engine": "knitr",
+    "markdown": "---\ntitle: \"simulist v0.7.0 (& v0.7.1) and publication in JOSS\"\nauthor:\n  - name: \"The Epiverse-TRACE development team\"\ndate: \"2026-03-10\"\ncategories: [new-release]\ncode-link: true\n---\n\n\n\n<!-- markdownlint-disable-next-line -->\nWe are very excited to announce that a publication accompanying the [simulist](https://epiverse-trace.github.io/simulist) package has now been published in the [Journal of Open Source Software (JOSS)](https://joss.theoj.org/): <https://joss.theoj.org/papers/10.21105/joss.08781>.\n\nThe simulist version coupled to the publication is v0.7.1, however most changes since v0.6.0 were released in v0.7.0 which is [available on CRAN](https://CRAN.R-project.org/package=simulist).\n\n\n\n::: {.cell}\n\n```{.r .cell-code}\nlibrary(simulist)\n```\n:::\n\n\n\nThe updates in the v0.7.0 release contain the JOSS paper (including `.md`, `.bib` and figures) and a range of small updates to simulation code and documentation: \n\n## New features\n\n* The sampling of sex for line list and contacts data can now be weighted instead of assuming a uniform probability via `prob_male` in `config` (#255).\n\n* The `reporting_delay` argument in `sim_linelist()` and `sim_outbreak()` now supports `<epiparameter>` objects, matching the functionality of the other delay distribution arguments (#262).\n\n* A new line list events plot has been added to the `vis-linelist.Rmd` vignette (#278).\n\n## Minor changes\n\n* Added `dependabot` (#258).\n\n* GitHub actions versions are updated (multiple PRs).\n\n* `.lintr` is updated to include more linters (#279) and the `# nolint` flag syntax is fixed (#263).\n\n---\n\nThe changes in v0.7.1 are minor edits to the JOSS paper for publication.\n\n## Acknowledgements\n\nThanks to the whole Epiverse community for their input on the development of the simulist R package.\n\nThanks to the team at JOSS for rewarding open source software, and the editors and reviewers for their helpful comments that improved the publication ([open review found here](https://github.com/openjournals/joss-reviews/issues/8781)).\n",
+    "supporting": [],
+    "filters": [
+      "rmarkdown/pagebreak.lua"
+    ],
+    "includes": {},
+    "engineDependencies": {},
+    "preserve": {},
+    "postProcess": true
+  }
+}

--- a/posts/simulist_joss/index.qmd
+++ b/posts/simulist_joss/index.qmd
@@ -1,0 +1,45 @@
+---
+title: "simulist v0.7.0 (& v0.7.1) and publication in JOSS"
+author:
+  - name: "The Epiverse-TRACE development team"
+date: "2026-03-10"
+categories: [new-release]
+code-link: true
+---
+
+<!-- markdownlint-disable-next-line -->
+We are very excited to announce that a publication accompanying the [simulist](https://epiverse-trace.github.io/simulist) package has now been published in the [Journal of Open Source Software (JOSS)](https://joss.theoj.org/): <https://joss.theoj.org/papers/10.21105/joss.08781>.
+
+The simulist version coupled to the publication is v0.7.1, however most changes since v0.6.0 were released in v0.7.0 which is [available on CRAN](https://CRAN.R-project.org/package=simulist).
+
+```{r}
+library(simulist)
+```
+
+The updates in the v0.7.0 release contain the JOSS paper (including `.md`, `.bib` and figures) and a range of small updates to simulation code and documentation: 
+
+## New features
+
+* The sampling of sex for line list and contacts data can now be weighted instead of assuming a uniform probability via `prob_male` in `config` (#255).
+
+* The `reporting_delay` argument in `sim_linelist()` and `sim_outbreak()` now supports `<epiparameter>` objects, matching the functionality of the other delay distribution arguments (#262).
+
+* A new line list events plot has been added to the `vis-linelist.Rmd` vignette (#278).
+
+## Minor changes
+
+* Added `dependabot` (#258).
+
+* GitHub actions versions are updated (multiple PRs).
+
+* `.lintr` is updated to include more linters (#279) and the `# nolint` flag syntax is fixed (#263).
+
+---
+
+The changes in v0.7.1 are minor edits to the JOSS paper for publication.
+
+## Acknowledgements
+
+Thanks to the whole Epiverse community for their input on the development of the simulist R package.
+
+Thanks to the team at JOSS for rewarding open source software, and the editors and reviewers for their helpful comments that improved the publication ([open review found here](https://github.com/openjournals/joss-reviews/issues/8781)).

--- a/posts/simulist_joss/index.qmd
+++ b/posts/simulist_joss/index.qmd
@@ -16,7 +16,7 @@ The simulist version coupled to the publication is v0.7.1, however most changes 
 library(simulist)
 ```
 
-The updates in the v0.7.0 release contain the JOSS paper (including `.md`, `.bib` and figures) and a range of small updates to simulation code and documentation: 
+The updates in the v0.7.0 release contain the JOSS paper (including `.md`, `.bib` and figures) and a range of small updates to simulation code and documentation:
 
 ## New features
 


### PR DESCRIPTION
This blog post documents the release of {simulist} v0.7.0 and v0.7.1 and also announces the publication in JOSS.

- [ ] The post specifies a license if you don't want to use the default CC BY
- [ ] All authors have an ORCID iD
- [ ] Relevant keywords / tags has been added. In particular, if you want your post to be shared on R-bloggers, you must tag it with `R`
- [ ] Images or other external resources have been committed and pushed
- [X] The post uses [pure quarto syntax, rather than HTML or R code, unless necessary](../CONTRIBUTING.md#pure-quarto-syntax)

Right before merging:

- [X] The `date` field has been updated
- [X] All reviewers have been acknowledged in a short paragraph
- [ ] A PR has been opened in the [`blueprints`](https://github.com/epiverse-trace/blueprints) to link to this post
- [X] The post has been re-rendered and content of the `_freeze/` folder is up-to-date
